### PR TITLE
Add password hash check after reset

### DIFF
--- a/tests/Feature/PasswordResetTest.php
+++ b/tests/Feature/PasswordResetTest.php
@@ -6,6 +6,7 @@ use Tests\TestCase;
 use App\Models\User;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class PasswordResetTest extends TestCase
@@ -64,6 +65,9 @@ class PasswordResetTest extends TestCase
             ]);
 
             $response->assertSessionHasNoErrors();
+
+            $user->refresh();
+            $this->assertTrue(Hash::check('password', $user->password));
 
             return true;
         });


### PR DESCRIPTION
## Summary
- verify password is actually changed in password reset test
- import `Hash` facade for assertions

## Testing
- `./vendor/bin/phpunit tests/Feature/PasswordResetTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6841d0934e8c83329b649ea0dd263a03