### PR TITLE
Fix currency formatting for empty orders

### DIFF
--- a/app/Services/OrderKPIService.php
+++ b/app/Services/OrderKPIService.php
@@ -166,15 +166,21 @@ class OrderKPIService
     public function getOrderMonthlyRemainingToDelivery($month ,$year)
     {
         $cacheKey = 'order_remaining_delivery_' . $month .'_'.  $year;
-        return Cache::remember($cacheKey, now()->addMinutes(10), function ()use ($year, $month) {
-            return DB::table('order_lines')
+        return Cache::remember($cacheKey, now()->addMinutes(10), function () use ($year, $month) {
+            $result = DB::table('order_lines')
                         ->selectRaw('
                             FLOOR(SUM((selling_price * delivered_remaining_qty)-(selling_price * delivered_remaining_qty)*(discount/100))) AS orderSum
                         ')
                         ->whereYear('delivery_date', '=', $year)
                         ->whereMonth('delivery_date', $month)
                         ->groupByRaw('MONTH(delivery_date) ')
-                        ->first() ?? (object) ['orderSum' => 0]; 
+                        ->first();
+
+            if (!$result || $result->orderSum === null) {
+                return (object) ['orderSum' => 0];
+            }
+
+            return $result;
         });
     }
 
@@ -194,16 +200,22 @@ class OrderKPIService
                         ')
                         ->join('orders', 'order_lines.orders_id', '=', 'orders.id');
 
-                        $query->where(function ($subQuery) {
-                            $subQuery->where('order_lines.invoice_status', 1)
-                                        ->orWhere('order_lines.invoice_status', 2);
-                            });
+            $query->where(function ($subQuery) {
+                $subQuery->where('order_lines.invoice_status', 1)
+                            ->orWhere('order_lines.invoice_status', 2);
+            });
 
-                        if ($companyId) {
-                            $query->where('orders.companies_id', $companyId);
-                        }
-                        
-            return  $query->first() ?? (object) ['orderSum' => 0];
+            if ($companyId) {
+                $query->where('orders.companies_id', $companyId);
+            }
+
+            $result = $query->first();
+
+            if (!$result || $result->orderSum === null) {
+                return (object) ['orderSum' => 0];
+            }
+
+            return $result;
         });
     }
 


### PR DESCRIPTION
## Summary
- ensure `OrderKPIService` returns a numeric value for remaining deliveries and invoices

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: no such file or directory)*
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684317457c2c8332a15de17f8223afeb