### PR TITLE
Replace euro sign with dollar

### DIFF
--- a/resources/views/methods/methods-services-show.blade.php
+++ b/resources/views/methods/methods-services-show.blade.php
@@ -16,7 +16,7 @@
             <p><strong>Code :</strong> {{ $service->code }}</p>
             <p><strong>Label :</strong> {{ $service->label }}</p>
             <p><strong>Type :</strong> {{ $service->type }}</p>
-            <p><strong>Taux Horaire :</strong> {{ number_format($service->hourly_rate, 2, ',', ' ') }} €</p>
+            <p><strong>Taux Horaire :</strong> {{ number_format($service->hourly_rate, 2, ',', ' ') }} $</p>
             <p><strong>Marge :</strong> {{ number_format($service->margin, 2, ',', ' ') }} %</p>
             <p><strong>Créé le :</strong> {{ $service->getPrettyCreatedAttribute() }}</p>
 
@@ -46,9 +46,9 @@
             var serviceChart = new Chart(ctx, {
                 type: 'bar',
                 data: {
-                    labels: ['Taux Horaire (€)', 'Marge (€)'],
+                    labels: ['Taux Horaire ($)', 'Marge ($)'],
                     datasets: [{
-                        label: 'Valeurs (€)',
+                        label: 'Valeurs ($)',
                         data: [
                             {{ $service->hourly_rate }}, 
                             {{ ($service->hourly_rate * (1 + $service->margin / 100))-$service->hourly_rate }}

--- a/resources/views/methods/methods-services.blade.php
+++ b/resources/views/methods/methods-services.blade.php
@@ -104,7 +104,7 @@
                             <div class="input-group-prepend">
                                 <span class="input-group-text">{{ $Factory->curency }}/h</span>
                             </div>
-                            <input type="number" class="form-control" name="hourly_rate" id="hourly_rate" placeholder="110 €/H" step=".001" value="{{ $MethodsService->hourly_rate }}">
+                            <input type="number" class="form-control" name="hourly_rate" id="hourly_rate" placeholder="110 $/H" step=".001" value="{{ $MethodsService->hourly_rate }}">
                           </div>
                         </div>
                         <div class="form-group">
@@ -236,7 +236,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text">{{ $Factory->curency }}/h</span>
                 </div>
-                <input type="number" class="form-control" name="hourly_rate" id="hourly_rate" placeholder="110 €/H" step=".001">
+                <input type="number" class="form-control" name="hourly_rate" id="hourly_rate" placeholder="110 $/H" step=".001">
               </div>
             </div>
             <div class="form-group">

--- a/resources/views/products/products-show.blade.php
+++ b/resources/views/products/products-show.blade.php
@@ -356,7 +356,7 @@
                         <td class="py-0 align-middle">
                             <!-- Button Modal -->
                             <button type="button" class="btn bg-teal" data-toggle="modal" data-target="#preferredSuppliers{{ $preferredSuppliers->id }}">
-                              x €
+                              x $
                             </button>
                             <!-- Modal {{ $preferredSuppliers->id }} -->
                             <x-adminlte-modal id="preferredSuppliers{{ $preferredSuppliers->id }}" title="{{ __('general_content.price_by_qty_trans_key') }} {{ $preferredSuppliers->label }}" theme="teal" icon="fa fa-pen" size='lg' disable-animations>


### PR DESCRIPTION
## Summary
- update currency symbol displayed in service and product pages from euro (€) to dollar ($)

## Testing
- `composer install --no-interaction` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847181ca6748332816c653e372a41b6