### PR TITLE
Update README with quoting prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ for run to production, follow this link :  [wiki page (install to run)](https://
 
 ![image](https://github.com/user-attachments/assets/f527881c-a7c4-460a-9b06-f647c91402d8)
 
+### Post-install configuration
+Before you can add quote lines you must set a default **VAT** and a default **Unit**.
+Open the application and navigate to **Accounting → VAT** and **Methods → Units**,
+then edit one item in each list and mark it as default. Without these defaults the
+quote form will refuse new lines.
+
 
 
 https://github.com/user-attachments/assets/200e1322-ae60-4270-aa9c-0a28e5ca737a

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -30,6 +30,12 @@ Pour une installation en production, suivez ce lien:  [wiki page (install to run
 
 ![image](https://github.com/user-attachments/assets/f527881c-a7c4-460a-9b06-f647c91402d8)
 
+### Configuration après installation
+Avant d'ajouter des lignes dans un devis, définissez une **TVA par défaut** et une **Unité par défaut**.
+Dans l'application allez dans **Comptabilité → TVA** puis dans **Méthodes → Unités**
+et marquez un élément comme valeur par défaut. Sans ces réglages il est impossible
+d'ajouter des lignes à un devis.
+
 
 
 


### PR DESCRIPTION
## Summary
- document that default VAT and unit must be configured before adding quote lines
- provide the same note in French docs

## Testing
- `phpunit --version` *(fails: command not found)*
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6847380089a08332b2e7657e2725d52c