### PR TITLE
Honor product VAT when creating lines

### DIFF
--- a/app/Livewire/OrderLine.php
+++ b/app/Livewire/OrderLine.php
@@ -175,10 +175,20 @@ class OrderLine extends Component
             $this->validate();
         }
 
-        $AccountingVat = AccountingVat::getDefault(); 
-        $MethodsUnits = MethodsUnits::getDefault(); 
-        $AccountingVat = ($AccountingVat->id  ?? 0);
-        $MethodsUnits = ($MethodsUnits->id  ?? 0);
+        // Determine VAT from product or fallback to default
+        $productVat = null;
+        if ($this->product_id) {
+            $product = Products::find($this->product_id);
+            if ($product) {
+                $productVat = $product->getAccountingVat();
+            }
+        }
+
+        $AccountingVatModel = $productVat ?: AccountingVat::getDefault();
+        $MethodsUnits = MethodsUnits::getDefault();
+
+        $AccountingVat = $AccountingVatModel->id ?? 0;
+        $MethodsUnits = $MethodsUnits->id ?? 0;
 
         if($AccountingVat == 0|| $MethodsUnits == 0 ){
             return redirect()->route('orders.show', ['id' =>  $this->orders_id])->with('error', 'No default settings');

--- a/app/Livewire/PurchasesLinesIndex.php
+++ b/app/Livewire/PurchasesLinesIndex.php
@@ -129,7 +129,16 @@ class PurchasesLinesIndex extends Component
             'methods_units_id'=>'required',
         ]);
 
-        $AccountingVat = $this->purchaseOrderService->getAccountingVat();
+        // Determine VAT from product or fallback to default
+        $productVat = null;
+        if ($this->product_id) {
+            $product = Products::find($this->product_id);
+            if ($product) {
+                $productVat = $product->getAccountingVat();
+            }
+        }
+
+        $AccountingVat = $productVat ?: $this->purchaseOrderService->getAccountingVat();
         if(!$AccountingVat){
             return redirect()->route('purchases.show', ['id' =>  $this->purchase_id])->with('error', 'No default settings');
         }

--- a/app/Livewire/QuoteLine.php
+++ b/app/Livewire/QuoteLine.php
@@ -87,17 +87,22 @@ class QuoteLine extends Component
     
     public function ChangeCodelabel()
     {
-        $product = Products::select('id', 'label', 'code', 'methods_units_id', 'selling_price')->where('id', $this->product_id)->get();
-        if(count($product) > 0){
-            $this->code = $product[0]->code ;
-            $this->label =  $product[0]->label;
-            $this->methods_units_id =  $product[0]->methods_units_id;
-            $this->selling_price =  $product[0]->selling_price;
-        }else{
-            $this->code ='';
-            $this->label ='';
-            $this->methods_units_id ='';
-            $this->selling_price ='';
+        $product = Products::select('id', 'label', 'code', 'methods_units_id', 'selling_price', 'tax')->where('id', $this->product_id)->get();
+        if (count($product) > 0) {
+            $this->code = $product[0]->code;
+            $this->label = $product[0]->label;
+            $this->methods_units_id = $product[0]->methods_units_id;
+            $this->selling_price = $product[0]->selling_price;
+
+            // Update VAT using the product's tax rate when available
+            $vat = $product[0]->getAccountingVat();
+            $this->accounting_vats_id = $vat ? $vat->id : null;
+        } else {
+            $this->code = '';
+            $this->label = '';
+            $this->methods_units_id = '';
+            $this->selling_price = '';
+            $this->accounting_vats_id = null;
         }
     }
 

--- a/app/Livewire/QuoteLine.php
+++ b/app/Livewire/QuoteLine.php
@@ -134,12 +134,20 @@ class QuoteLine extends Component
 
     public function storeQuoteLine(){
         $this->validate();
-        // Create Line
-        
-        $AccountingVat = AccountingVat::getDefault(); 
-        $MethodsUnits = MethodsUnits::getDefault(); 
-        $AccountingVat = ($AccountingVat->id  ?? 0);
-        $MethodsUnits = ($MethodsUnits->id  ?? 0);
+        // Determine VAT from product or fallback to default
+        $productVat = null;
+        if ($this->product_id) {
+            $product = Products::find($this->product_id);
+            if ($product) {
+                $productVat = $product->getAccountingVat();
+            }
+        }
+
+        $AccountingVatModel = $productVat ?: AccountingVat::getDefault();
+        $MethodsUnits = MethodsUnits::getDefault();
+
+        $AccountingVat = $AccountingVatModel->id ?? 0;
+        $MethodsUnits = $MethodsUnits->id ?? 0;
 
         if($AccountingVat == 0|| $MethodsUnits == 0 ){
             return redirect()->route('quotes.show', ['id' =>  $this->quotes_id])->with('error', 'No VAT or Unit default settings');

--- a/app/Models/Products/Products.php
+++ b/app/Models/Products/Products.php
@@ -13,6 +13,7 @@ use App\Models\Methods\MethodsUnits;
 use App\Models\Planning\SubAssembly;
 use App\Models\Methods\MethodsFamilies;
 use App\Models\Methods\MethodsServices;
+use App\Models\Accounting\AccountingVat;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\Activitylog\Traits\LogsActivity;
@@ -337,7 +338,7 @@ class Products extends Model
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()->logOnly(['code',
-                                                'label', 
+                                                'label',
                                                 'ind',
                                                 'methods_services_id', 
                                                 'methods_families_id', 
@@ -370,5 +371,19 @@ class Products extends Model
                                                 'svg_file',
                                                 'csv_file_name',]);
         // Chain fluent methods for configuration options
+    }
+
+    /**
+     * Retrieve the accounting VAT associated with the product tax rate.
+     *
+     * @return AccountingVat|null
+     */
+    public function getAccountingVat()
+    {
+        if (is_null($this->tax)) {
+            return null;
+        }
+
+        return AccountingVat::where('rate', $this->tax)->first();
     }
 }


### PR DESCRIPTION
## Summary
- use product's `tax` to pick the accounting VAT record
- derive VAT from the product when adding quote/order/purchase lines

## Testing
- `php -v` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68473c0470bc8332904239d6a307c7ff