### PR TITLE
Allow duplicate VAT rates

### DIFF
--- a/app/Http/Requests/Accounting/StoreVatRequest.php
+++ b/app/Http/Requests/Accounting/StoreVatRequest.php
@@ -27,7 +27,7 @@ class StoreVatRequest extends FormRequest
             //
             'code' =>'required|unique:accounting_vats',
             'label'=>'required',
-            'rate'=>'required|unique:accounting_vats',
+            'rate'=>'required',
         ];
     }
 }

--- a/app/Http/Requests/Accounting/UpdateVatRequest.php
+++ b/app/Http/Requests/Accounting/UpdateVatRequest.php
@@ -26,7 +26,7 @@ class UpdateVatRequest extends FormRequest
         return [
             //
             'label'=>'required',
-            'rate'=>'required|unique:accounting_vats,rate,'. $this->id,
+            'rate'=>'required',
             'default'=>'integer',
         ];
     }


### PR DESCRIPTION
## Summary
- permit non-unique VAT rates in store/update requests

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68474a662b888332be764b7fa85e7133