### PR TITLE
Fix menu label for families

### DIFF
--- a/resources/lang/vendor/adminlte/en/menu.php
+++ b/resources/lang/vendor/adminlte/en/menu.php
@@ -61,7 +61,7 @@ return [
     'methods_sections_trans_key'               => 'Sections',
     'methods_locations_trans_key'              => 'Locations',
     'methods_units_trans_key'                  => 'Units',
-    'methods_familys_trans_key'                => 'Famillys',
+    'methods_familys_trans_key'                => 'Categories',
     'methods_tools_trans_key'                  => 'Tools',
     'methods_standard_bom_trans_key'           => 'Nomenclature standard',
     'accounting_trans_key'                     => 'Accounting',


### PR DESCRIPTION
## Summary
- change English menu label from `Famillys` to `Categories`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684752d6e3a48332ac51e5649cdb6955