### PR TITLE
Add province field to company addresses

### DIFF
--- a/app/Http/Requests/Companies/StoreAdressRequest.php
+++ b/app/Http/Requests/Companies/StoreAdressRequest.php
@@ -31,6 +31,7 @@ class StoreAdressRequest extends FormRequest
             'adress'=>'required',
             'zipcode'=>'required',
             'city'=>'required',
+            'province'=>'nullable|string',
             'country'=>'required',
             'number'=>'nullable|string',
             'mail'=>'nullable|string',

--- a/app/Http/Requests/Companies/UpdateAdressRequest.php
+++ b/app/Http/Requests/Companies/UpdateAdressRequest.php
@@ -30,6 +30,7 @@ class UpdateAdressRequest extends FormRequest
             'adress'=>'required',
             'zipcode'=>'required',
             'city'=>'required',
+            'province'=>'nullable|string',
             'country'=>'required',
             'number'=>'nullable|string',
             'mail'=>'nullable|string',

--- a/app/Http/Resources/AdresseResource.php
+++ b/app/Http/Resources/AdresseResource.php
@@ -18,6 +18,7 @@ class AdresseResource extends JsonResource
             'adress' => $this->adress,
             'zipcode' => $this->zipcode,
             'city' => $this->city,
+            'province' => $this->province,
             'country' => $this->country,
             'number' => $this->number,
             'mail' => $this->mail,

--- a/app/Http/Resources/CompanieResource.php
+++ b/app/Http/Resources/CompanieResource.php
@@ -40,6 +40,7 @@ class CompanieResource extends JsonResource
                     'adress' => $address->adress,
                     'zipcode' => $address->zipcode,
                     'city' => $address->city,
+                    'province' => $address->province,
                     'country' => $address->country,
                 ];
             }),

--- a/app/Models/Companies/CompaniesAddresses.php
+++ b/app/Models/Companies/CompaniesAddresses.php
@@ -12,7 +12,7 @@ class CompaniesAddresses extends Model
     use HasFactory, HasDefaultTrait;
 
     // Fillable attributes for mass assignment
-    protected $fillable= ['companies_id', 'ordre', 'label', 'adress','zipcode','city','country','number','mail', 'default'];
+    protected $fillable= ['companies_id', 'ordre', 'label', 'adress','zipcode','city','province','country','number','mail', 'default'];
     
     public $timestamps = false;
 

--- a/database/factories/Companies/CompaniesAddressesFactory.php
+++ b/database/factories/Companies/CompaniesAddressesFactory.php
@@ -32,6 +32,7 @@ class CompaniesAddressesFactory extends Factory
             'adress' => $this->faker->secondaryAddress(),
             'zipcode' => $this->faker->postcode(),
             'city' => $City,
+            'province' => $this->faker->state(),
             'country' => $this->faker->country(),
             'number' => $this->faker->phoneNumber(),
             'mail' => $this->faker->unique()->safeEmail(),

--- a/database/migrations/2021_07_18_235122_create_companies_addresses_table.php
+++ b/database/migrations/2021_07_18_235122_create_companies_addresses_table.php
@@ -21,8 +21,9 @@ class CreateCompaniesAddressesTable extends Migration {
 			$table->string('label');
 			$table->string('adress')->nullable();
 			$table->string('zipcode')->nullable();
-			$table->string('city')->nullable();
-			$table->string('country')->nullable();
+                        $table->string('city')->nullable();
+                        $table->string('province')->nullable();
+                        $table->string('country')->nullable();
 			$table->string('number')->nullable();
 			$table->string('mail')->nullable();
 			$table->timestamps();

--- a/database/migrations/2025_06_10_000001_add_province_to_companies_addresses_table.php
+++ b/database/migrations/2025_06_10_000001_add_province_to_companies_addresses_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('companies_addresses', function (Blueprint $table) {
+            $table->string('province')->nullable()->after('city');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('companies_addresses', function (Blueprint $table) {
+            $table->dropColumn('province');
+        });
+    }
+};

--- a/resources/views/companies/companies-show.blade.php
+++ b/resources/views/companies/companies-show.blade.php
@@ -435,6 +435,7 @@
                       <th>{{ __('general_content.adress_trans_key') }}</th>
                       <th>{{ __('general_content.postal_code_trans_key') }}</th>
                       <th>{{ __('general_content.city_trans_key') }}</th>
+                      <th>{{ __('general_content.province_trans_key') }}</th>
                       <th>{{ __('general_content.country_trans_key') }}</th>
                       <th>{{ __('general_content.phone_trans_key') }}</th>
                       <th>{{ __('general_content.email_trans_key') }}</th>
@@ -450,6 +451,7 @@
                       <td>{{ $Address->adress }}</td>
                       <td>{{ $Address->zipcode }}</td>
                       <td>{{ $Address->city }}</td>
+                      <td>{{ $Address->province }}</td>
                       <td>{{ $Address->country }}</td>
                       <td>{{ $Address->number }}</td>
                       <td>{{ $Address->mail }}</td>
@@ -510,6 +512,12 @@
                               </div>
                               <div class="row">
                                 <div class="form-group col-md-12">
+                                  <label for="province">{{ __('general_content.province_trans_key') }}</label>
+                                  <input type="text" class="form-control" name="province"  id="province" placeholder="{{ __('general_content.province_trans_key') }}" value="{{ $Address->province }}">
+                                </div>
+                              </div>
+                              <div class="row">
+                                <div class="form-group col-md-12">
                                   <label for="country">{{ __('general_content.country_trans_key') }}</label>
                                   <input type="text" class="form-control" name="country"  id="country" placeholder="{{ __('general_content.country_trans_key') }}" value="{{ $Address->country }}">
                                 </div>
@@ -553,10 +561,11 @@
                   <tfoot>
                     <tr>
                       <th>#</th>
-                      <th>{{ __('general_content.postal_code_trans_key') }}</th>
+                      <th>{{ __('general_content.label_trans_key') }}</th>
                       <th>{{ __('general_content.adress_trans_key') }}</th>
                       <th>{{ __('general_content.postal_code_trans_key') }}</th>
                       <th>{{ __('general_content.city_trans_key') }}</th>
+                      <th>{{ __('general_content.province_trans_key') }}</th>
                       <th>{{ __('general_content.country_trans_key') }}</th>
                       <th>{{ __('general_content.phone_trans_key') }}</th>
                       <th>{{ __('general_content.email_trans_key') }}</th>
@@ -613,6 +622,12 @@
                   <div class="form-group col-md-12">
                     <label for="city">{{ __('general_content.city_trans_key') }}</label>
                     <input type="text" class="form-control" name="city"  id="city" placeholder="{{ __('general_content.city_trans_key') }}">
+                  </div>
+                </div>
+                <div class="row">
+                  <div class="form-group col-md-12">
+                    <label for="province">{{ __('general_content.province_trans_key') }}</label>
+                    <input type="text" class="form-control" name="province"  id="province" placeholder="{{ __('general_content.province_trans_key') }}">
                   </div>
                 </div>
                 <div class="row">

--- a/resources/views/guest/guest-delivery-info.blade.php
+++ b/resources/views/guest/guest-delivery-info.blade.php
@@ -211,7 +211,7 @@
                                     <strong>{{ $Delivery->companie['label'] }}</strong><br>
                                     {{ $Delivery->contact['civility'] }} {{ $Delivery->contact['first_name'] }} {{ $Delivery->contact['name'] }}<br>
                                     {{ $Delivery->adresse['adress'] }}<br>
-                                    {{ $Delivery->adresse['zipcode'] }} {{ $Delivery->adresse['city'] }}<br>
+                                    {{ $Delivery->adresse['zipcode'] }} {{ $Delivery->adresse['city'] }} {{ $Delivery->adresse['province'] ?? '' }}<br>
                                     {{ $Delivery->adresse['country'] }}<br>
                                 </address>
                             </div>

--- a/resources/views/guest/guest-order-info.blade.php
+++ b/resources/views/guest/guest-order-info.blade.php
@@ -277,7 +277,7 @@
                                     <strong>{{ $Order->companie['label'] }}</strong><br>
                                     {{ $Order->contact['civility'] }} {{ $Order->contact['first_name'] }} {{ $Order->contact['name'] }}<br>
                                     {{ $Order->adresse['adress'] }}<br>
-                                    {{ $Order->adresse['zipcode'] }} {{ $Order->adresse['city'] }}<br>
+                                    {{ $Order->adresse['zipcode'] }} {{ $Order->adresse['city'] }} {{ $Order->adresse['province'] ?? '' }}<br>
                                     {{ $Order->adresse['country'] }}<br>
                                 </address>
                             </div>

--- a/resources/views/guest/guest-quote-info.blade.php
+++ b/resources/views/guest/guest-quote-info.blade.php
@@ -245,7 +245,7 @@
                                     <strong>{{ $Quote->companie['label'] }}</strong><br>
                                     {{ $Quote->contact['civility'] }} {{ $Quote->contact['first_name'] }} {{ $Quote->contact['name'] }}<br>
                                     {{ $Quote->adresse['adress'] }}<br>
-                                    {{ $Quote->adresse['zipcode'] }} {{ $Quote->adresse['city'] }}<br>
+                                    {{ $Quote->adresse['zipcode'] }} {{ $Quote->adresse['city'] }} {{ $Quote->adresse['province'] ?? '' }}<br>
                                     {{ $Quote->adresse['country'] }}<br>
                                 </address>
                             </div>

--- a/resources/views/livewire/leads-index.blade.php
+++ b/resources/views/livewire/leads-index.blade.php
@@ -218,7 +218,7 @@
                         <td>#{{ $Lead->id }}</td>
                         <td><x-CompanieButton id="{{ $Lead->companies_id }}" label="{{ $Lead->companie['label'] }}"  /></td>
                         <td>{{ $Lead->companie['first_name'] }} {{ $Lead->contact['name'] }}</td>
-                        <td>{{ $Lead->adresse['adress'] }} {{ $Lead->adresse['zipcode'] }}  {{ $Lead->adresse['city'] }}</td>
+                        <td>{{ $Lead->adresse['adress'] }} {{ $Lead->adresse['zipcode'] }}  {{ $Lead->adresse['city'] }} {{ $Lead->adresse['province'] ?? '' }}</td>
                         <td><img src="{{ Avatar::create($Lead->UserManagement['name'])->toBase64() }}" /></td>
                         <td>{{ $Lead->source }}</td>
                         <td>
@@ -294,7 +294,7 @@
                         </div>
                         <div class="card-body">
                             <p class="card-text">{{ $Lead->companie['first_name'] }} {{ $Lead->contact['name'] }}</p>
-                            <p class="card-text">{{ $Lead->adresse['adress'] }} {{ $Lead->adresse['zipcode'] }}  {{ $Lead->adresse['city'] }}</p>
+                            <p class="card-text">{{ $Lead->adresse['adress'] }} {{ $Lead->adresse['zipcode'] }}  {{ $Lead->adresse['city'] }} {{ $Lead->adresse['province'] ?? '' }}</p>
                             <p class="card-text"><strong>{{ __('general_content.source_trans_key') }}</strong> : {{ $Lead->source }}</p>
                             <p class="card-text"><strong>{{ __('general_content.campaign_trans_key') }}</strong> : {{ $Lead->campaign }}</p>
                             <p class="card-text"><strong>{{ __('general_content.status_trans_key') }}</strong>

--- a/resources/views/print/pdf-credit-note.blade.php
+++ b/resources/views/print/pdf-credit-note.blade.php
@@ -68,7 +68,7 @@
                             <pre>
 {{ $Document->contact['civility'] }} {{ $Document->contact['first_name'] }} {{ $Document->contact['name'] }}
 {{ $Document->adresse['adress'] }}
-{{ $Document->adresse['zipcode'] }} {{ $Document->adresse['city'] }}
+{{ $Document->adresse['zipcode'] }} {{ $Document->adresse['city'] }} {{ $Document->adresse['province'] ?? '' }}
 {{ $Document->adresse['country'] }}
 {{ __('general_content.phone_trans_key') }} : {{ $Document->contact['number'] }}
 {{ __('general_content.email_trans_key') }} : {{ $Document->contact['mail'] }}

--- a/resources/views/print/pdf-delivery.blade.php
+++ b/resources/views/print/pdf-delivery.blade.php
@@ -70,7 +70,7 @@
                             <pre>
 {{ $Document->contact['civility'] }} {{ $Document->contact['first_name'] }} {{ $Document->contact['name'] }}
 {{ $Document->adresse['adress'] }}
-{{ $Document->adresse['zipcode'] }} {{ $Document->adresse['city'] }}
+{{ $Document->adresse['zipcode'] }} {{ $Document->adresse['city'] }} {{ $Document->adresse['province'] ?? '' }}
 {{ $Document->adresse['country'] }}
 {{ __('general_content.phone_trans_key') }} : {{ $Document->contact['number'] }}
 {{ __('general_content.email_trans_key') }} : {{ $Document->contact['mail'] }}

--- a/resources/views/print/pdf-invoice.blade.php
+++ b/resources/views/print/pdf-invoice.blade.php
@@ -68,7 +68,7 @@
                             <pre>
 {{ $Document->contact['civility'] }} {{ $Document->contact['first_name'] }} {{ $Document->contact['name'] }}
 {{ $Document->adresse['adress'] }}
-{{ $Document->adresse['zipcode'] }} {{ $Document->adresse['city'] }}
+{{ $Document->adresse['zipcode'] }} {{ $Document->adresse['city'] }} {{ $Document->adresse['province'] ?? '' }}
 {{ $Document->adresse['country'] }}
 {{ __('general_content.phone_trans_key') }} : {{ $Document->contact['number'] }}
 {{ __('general_content.email_trans_key') }} : {{ $Document->contact['mail'] }}

--- a/resources/views/print/pdf-purchases-quotation.blade.php
+++ b/resources/views/print/pdf-purchases-quotation.blade.php
@@ -67,7 +67,7 @@
                             <pre>
 {{ $Document->contact['civility'] }} {{ $Document->contact['first_name'] }} {{ $Document->contact['name'] }}
 {{ $Document->adresse['adress'] }}
-{{ $Document->adresse['zipcode'] }} {{ $Document->adresse['city'] }}
+{{ $Document->adresse['zipcode'] }} {{ $Document->adresse['city'] }} {{ $Document->adresse['province'] ?? '' }}
 {{ $Document->adresse['country'] }}
 {{ __('general_content.phone_trans_key') }} : {{ $Document->contact['number'] }}
 {{ __('general_content.email_trans_key') }} : {{ $Document->contact['mail'] }}

--- a/resources/views/print/pdf-purchases.blade.php
+++ b/resources/views/print/pdf-purchases.blade.php
@@ -69,7 +69,7 @@
                             <pre>
 {{ $Document->contact['civility'] }} {{ $Document->contact['first_name'] }} {{ $Document->contact['name'] }}
 {{ $Document->adresse['adress'] }}
-{{ $Document->adresse['zipcode'] }} {{ $Document->adresse['city'] }}
+{{ $Document->adresse['zipcode'] }} {{ $Document->adresse['city'] }} {{ $Document->adresse['province'] ?? '' }}
 {{ $Document->adresse['country'] }}
 {{ __('general_content.phone_trans_key') }} : {{ $Document->contact['number'] }}
 {{ __('general_content.email_trans_key') }} : {{ $Document->contact['mail'] }}

--- a/resources/views/print/pdf-sales.blade.php
+++ b/resources/views/print/pdf-sales.blade.php
@@ -72,7 +72,7 @@
                             <pre>
 {{ $Document->contact['civility'] }} {{ $Document->contact['first_name'] }} {{ $Document->contact['name'] }}
 {{ $Document->adresse['adress'] }}
-{{ $Document->adresse['zipcode'] }} {{ $Document->adresse['city'] }}
+{{ $Document->adresse['zipcode'] }} {{ $Document->adresse['city'] }} {{ $Document->adresse['province'] ?? '' }}
 {{ $Document->adresse['country'] }}
 {{ __('general_content.phone_trans_key') }} : {{ $Document->contact['number'] }}
 {{ __('general_content.email_trans_key') }} : {{ $Document->contact['mail'] }}

--- a/resources/views/print/print-manufacturing-instruction.blade.php
+++ b/resources/views/print/print-manufacturing-instruction.blade.php
@@ -54,6 +54,7 @@
                             companieAdress="{{ $Document->adresse['adress'] }}"
                             companieZipcode="{{ $Document->adresse['zipcode'] }}"
                             companieCity="{{ $Document->adresse['city'] }}"
+                            companieProvince="{{ $Document->adresse['province'] ?? '' }}"
                             companieCountry="{{ $Document->adresse['country'] }}"
                             companieNumber="{{ $Document->contact['number'] }}"
                             companieMail="{{ $Document->contact['mail'] }}"


### PR DESCRIPTION
## Summary
- add province column to companies addresses table
- include province in model, resources, and validation
- collect province in factories and forms
- display province across views and print templates

## Testing
- `phpunit` *(fails: vendor not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847569ef37c8332b863274bfb7edae8