### PR TITLE
Add basic reports dashboard

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\OrderKPIService;
+use App\Services\QuoteKPIService;
+
+class ReportsController extends Controller
+{
+    protected $orderKPIService;
+    protected $quoteKPIService;
+
+    public function __construct(OrderKPIService $orderKPIService, QuoteKPIService $quoteKPIService)
+    {
+        $this->orderKPIService = $orderKPIService;
+        $this->quoteKPIService = $quoteKPIService;
+    }
+
+    /**
+     * Display the reports dashboard.
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function index()
+    {
+        $deliveredOrdersPercentage = $this->orderKPIService->getDeliveredOrdersPercentage();
+        $invoicedOrdersPercentage  = $this->orderKPIService->getInvoicedOrdersPercentage();
+        $serviceRate               = $this->orderKPIService->getServiceRate();
+
+        $averageQuoteAmount = $this->quoteKPIService->getAverageQuoteAmount();
+        $conversionRate     = $this->quoteKPIService->getQuoteConversionRate();
+        $responseRate       = $this->quoteKPIService->getQuoteResponseRate();
+
+        $topOrderCustomers = $this->orderKPIService->getTopCustomersByOrderVolume(5);
+        $topQuoteCustomers = $this->quoteKPIService->getTopCustomersByQuoteVolume(5);
+
+        return view('reports.index', compact(
+            'deliveredOrdersPercentage',
+            'invoicedOrdersPercentage',
+            'serviceRate',
+            'averageQuoteAmount',
+            'conversionRate',
+            'responseRate',
+            'topOrderCustomers',
+            'topQuoteCustomers'
+        ));
+    }
+}

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -7,5 +7,64 @@
 @stop
 
 @section('content')
-    <p class="text-muted">{{ __('general_content.coming_soon_trans_key') ?? 'Coming soon' }}</p>
+<div class="row">
+    <div class="col-lg-4">
+        <x-adminlte-small-box title="{{ $deliveredOrdersPercentage }}%"
+                              text="{{ __('general_content.order_delivered_trans_key') }}"
+                              icon="fas fa-shipping-fast" theme="success" />
+    </div>
+    <div class="col-lg-4">
+        <x-adminlte-small-box title="{{ $invoicedOrdersPercentage }}%"
+                              text="{{ __('general_content.order_invoiced_trans_key') }}"
+                              icon="fas fa-file-invoice-dollar" theme="info" />
+    </div>
+    <div class="col-lg-4">
+        <x-adminlte-small-box title="{{ $serviceRate }}%"
+                              text="{{ __('general_content.service_rate_trans_key') }}"
+                              icon="fas fa-chart-line" theme="primary" />
+    </div>
+</div>
+
+<div class="row mt-4">
+    <div class="col-lg-4">
+        <x-adminlte-small-box title="{{ number_format($averageQuoteAmount,2) }}"
+                              text="{{ __('general_content.average_quote_amount') }}"
+                              icon="fas fa-file-signature" theme="teal" />
+    </div>
+    <div class="col-lg-4">
+        <x-adminlte-small-box title="{{ $conversionRate }}%"
+                              text="{{ __('general_content.quote_conversion_rate') }}"
+                              icon="fas fa-exchange-alt" theme="warning" />
+    </div>
+    <div class="col-lg-4">
+        <x-adminlte-small-box title="{{ $responseRate }}%"
+                              text="{{ __('general_content.quote_response_rate') }}"
+                              icon="fas fa-chart-pie" theme="purple" />
+    </div>
+</div>
+
+<div class="row mt-4">
+    <div class="col-md-6">
+        <x-adminlte-card title="{{ __('general_content.top_customers_trans_key') }}" theme="secondary" maximizable>
+            <ul class="list-group list-group-flush">
+                @foreach($topOrderCustomers as $customer)
+                    <li class="list-group-item">
+                        <strong>{{ $customer->companie->label ?? 'Internal' }}</strong> - {{ $customer->order_count }}
+                    </li>
+                @endforeach
+            </ul>
+        </x-adminlte-card>
+    </div>
+    <div class="col-md-6">
+        <x-adminlte-card title="{{ __('general_content.top_customers_trans_key') }} ({{ __('general_content.quote_trans_key') }})" theme="secondary" maximizable>
+            <ul class="list-group list-group-flush">
+                @foreach($topQuoteCustomers as $customer)
+                    <li class="list-group-item">
+                        <strong>{{ $customer->companie->label ?? 'Internal' }}</strong> - {{ $customer->quote_count }}
+                    </li>
+                @endforeach
+            </ul>
+        </x-adminlte-card>
+    </div>
+</div>
 @stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,9 +27,8 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
     Route::post('/order/ratings', 'App\Http\Controllers\Workflow\OrdersRatingController@store')->name('order.ratings.store');
 
     Route::get('/dashboard', 'App\Http\Controllers\HomeController@index')->middleware(['auth', 'check.factory'])->name('dashboard');
-    Route::get('/reports', function () {
-        return view('reports.index');
-    })->middleware(['auth', 'check.factory'])->name('reports');
+    Route::get('/reports', 'App\\Http\\Controllers\\ReportsController@index')
+        ->middleware(['auth', 'check.factory'])->name('reports');
 
     Route::group(['prefix' => 'workshop', 'middleware' => ['auth', 'check.factory']], function () {
         Route::get('/', 'App\Http\Controllers\Workshop\WorkshopController@index')->middleware(['auth', 'check.factory'])->name('workshop');


### PR DESCRIPTION
## Summary
- implement `ReportsController` with aggregated KPIs
- show delivered and invoiced orders, service rate, quote KPIs
- list top customers for orders and quotes
- hook `/reports` route to the new controller
- fill reports view with basic metrics instead of placeholder

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475da788508332bc11e01705e331be