### PR TITLE
Add accounting reports with PDF export

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Services\OrderKPIService;
 use App\Services\QuoteKPIService;
+use App\Services\AccountingReportService;
 
 class ReportsController extends Controller
 {
@@ -44,5 +45,17 @@ class ReportsController extends Controller
             'topOrderCustomers',
             'topQuoteCustomers'
         ));
+    }
+
+    /**
+     * Display accounting reports summary.
+     */
+    public function accounting(AccountingReportService $accountingReportService)
+    {
+        $revenue  = $accountingReportService->getTotalRevenue();
+        $expenses = $accountingReportService->getTotalExpense();
+        $profit   = $accountingReportService->getProfit();
+
+        return view('reports.accounting', compact('revenue', 'expenses', 'profit'));
     }
 }

--- a/app/Services/AccountingReportService.php
+++ b/app/Services/AccountingReportService.php
@@ -1,0 +1,27 @@
+<?php
+namespace App\Services;
+
+use App\Models\Workflow\Invoices;
+use App\Models\Purchases\Purchases;
+
+class AccountingReportService
+{
+    public function getTotalRevenue()
+    {
+        return Invoices::all()->sum(function ($invoice) {
+            return $invoice->getTotalPriceAttribute();
+        });
+    }
+
+    public function getTotalExpense()
+    {
+        return Purchases::all()->sum(function ($purchase) {
+            return $purchase->getTotalPriceAttribute();
+        });
+    }
+
+    public function getProfit()
+    {
+        return $this->getTotalRevenue() - $this->getTotalExpense();
+    }
+}

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -640,10 +640,22 @@ return [
             ],
         ],
         [
-            'text' => 'Reports',
+            'text' => 'reports_trans_key',
             'icon' => 'fas fa-chart-pie',
-            'url'  => 'reports',
             'icon_color' => 'purple',
+            'url'  => 'reports',
+            'submenu' => [
+                [
+                    'text' => 'dashboard_trans_key',
+                    'url'  => 'reports',
+                    'icon_color' => 'purple',
+                ],
+                [
+                    'text' => 'accounting_reports_trans_key',
+                    'url'  => 'reports/accounting',
+                    'icon_color' => 'cyan',
+                ],
+            ],
         ],
         [
             'text' => 'your_company_trans_key',

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -914,6 +914,10 @@ return [
     'licence_trans_key'                     => 'ترخيص',
     'release_note_trans_key'                => 'ملاحظات الإصدار',
     'reports_trans_key'                     => 'التقارير',
+    'accounting_reports_trans_key'          => 'تقارير المحاسبة',
+    'total_revenue_trans_key'               => 'إجمالي الإيرادات',
+    'total_expense_trans_key'               => 'إجمالي المصروفات',
+    'total_profit_trans_key'                => 'الربح',
     'coming_soon_trans_key'                 => 'قريباً',
 
     'search_results_trans_key'              => 'نتائج البحث',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -1082,6 +1082,10 @@ return [
     'licence_trans_key'                        => 'Licence',
     'release_note_trans_key'                   => 'Release notes',
     'reports_trans_key'                        => 'Reports',
+    'accounting_reports_trans_key'             => 'Accounting Reports',
+    'total_revenue_trans_key'                  => 'Total Revenue',
+    'total_expense_trans_key'                  => 'Total Expenses',
+    'total_profit_trans_key'                   => 'Profit',
     'coming_soon_trans_key'                    => 'Coming soon',
     
     'search_results_trans_key'                 => 'Search results',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -915,6 +915,10 @@ return [
     'licence_trans_key'                    => 'Licencia',
     'release_note_trans_key'               => 'Notas de la versión',
     'reports_trans_key'                    => 'Informes',
+    'accounting_reports_trans_key'         => 'Informes contables',
+    'total_revenue_trans_key'              => 'Ingresos totales',
+    'total_expense_trans_key'              => 'Gastos totales',
+    'total_profit_trans_key'               => 'Beneficio',
     'coming_soon_trans_key'                => 'Próximamente',
 
     'search_results_trans_key'             => 'Resultados de búsqueda',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -1082,6 +1082,10 @@ return [
     'licence_trans_key'                        => 'Licence',
     'release_note_trans_key'                   => 'Notes de version',
     'reports_trans_key'                        => 'Rapports',
+    'accounting_reports_trans_key'             => 'Rapports comptables',
+    'total_revenue_trans_key'                  => 'Revenus totaux',
+    'total_expense_trans_key'                  => 'Dépenses totales',
+    'total_profit_trans_key'                   => 'Bénéfice',
     'coming_soon_trans_key'                    => 'Bientôt disponible',
 
     'search_results_trans_key'                 => 'Résulta de la recherche',

--- a/resources/lang/vi/general_content.php
+++ b/resources/lang/vi/general_content.php
@@ -115,6 +115,10 @@ return [
     'licence_trans_key'                        => 'Giấy phép',
     'release_note_trans_key'                   => 'Nhật ký phát hành',
     'reports_trans_key'                        => 'Báo cáo',
+    'accounting_reports_trans_key'             => 'Báo cáo kế toán',
+    'total_revenue_trans_key'                  => 'Tổng doanh thu',
+    'total_expense_trans_key'                  => 'Tổng chi phí',
+    'total_profit_trans_key'                   => 'Lợi nhuận',
     'coming_soon_trans_key'                    => 'Sắp ra mắt',
     
     'search_results_trans_key'                 => 'Kết quả tìm kiếm',

--- a/resources/views/livewire/fec-export-lines.blade.php
+++ b/resources/views/livewire/fec-export-lines.blade.php
@@ -14,13 +14,22 @@
                         </button> 
                     </div>
                     <div class="btn-group">
-                        <button 
+                        <button
                                 class="btn btn-danger float-sm-right"
                                 type="button"
                                 wire:click="export('xlsx')"
                                 wire:loading.attr="disabled"  >
                             XLS
-                        </button> 
+                        </button>
+                    </div>
+                    <div class="btn-group">
+                        <button
+                                class="btn btn-primary float-sm-right"
+                                type="button"
+                                wire:click="export('pdf')"
+                                wire:loading.attr="disabled"  >
+                            PDF
+                        </button>
                     </div>
                 </div>
             </div>

--- a/resources/views/reports/accounting.blade.php
+++ b/resources/views/reports/accounting.blade.php
@@ -1,0 +1,30 @@
+@extends('adminlte::page')
+
+@section('title', __('general_content.accounting_reports_trans_key'))
+
+@section('content_header')
+    <h1>{{ __('general_content.accounting_reports_trans_key') }}</h1>
+@stop
+
+@section('content')
+<div class="row">
+    <div class="col-md-4">
+        <x-adminlte-card title="{{ __('general_content.total_revenue_trans_key') }}" theme="success" icon="fas fa-coins" >
+            {{ \Illuminate\Support\Number::currency($revenue, app('Factory')->curency, config('app.locale')) }}
+        </x-adminlte-card>
+    </div>
+    <div class="col-md-4">
+        <x-adminlte-card title="{{ __('general_content.total_expense_trans_key') }}" theme="danger" icon="fas fa-file-invoice-dollar" >
+            {{ \Illuminate\Support\Number::currency($expenses, app('Factory')->curency, config('app.locale')) }}
+        </x-adminlte-card>
+    </div>
+    <div class="col-md-4">
+        <x-adminlte-card title="{{ __('general_content.total_profit_trans_key') }}" theme="primary" icon="fas fa-chart-line" >
+            {{ \Illuminate\Support\Number::currency($profit, app('Factory')->curency, config('app.locale')) }}
+        </x-adminlte-card>
+    </div>
+</div>
+<div class="mt-4">
+    @livewire('fec-export-lines')
+</div>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,8 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
     Route::get('/dashboard', 'App\Http\Controllers\HomeController@index')->middleware(['auth', 'check.factory'])->name('dashboard');
     Route::get('/reports', 'App\\Http\\Controllers\\ReportsController@index')
         ->middleware(['auth', 'check.factory'])->name('reports');
+    Route::get('/reports/accounting', 'App\\Http\\Controllers\\ReportsController@accounting')
+        ->middleware(['auth', 'check.factory'])->name('reports.accounting');
 
     Route::group(['prefix' => 'workshop', 'middleware' => ['auth', 'check.factory']], function () {
         Route::get('/', 'App\Http\Controllers\Workshop\WorkshopController@index')->middleware(['auth', 'check.factory'])->name('workshop');


### PR DESCRIPTION
## Summary
- introduce `AccountingReportService` to compute revenue, expenses and profit
- extend `ReportsController` with an accounting view
- add routing and menu entries for Accounting reports
- show totals and FEC export with PDF option
- update translations for new texts

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684760625f2c83329747f4dd23617ade