### PR TITLE
Add processing location display in Quotes list

### DIFF
--- a/app/Livewire/QuotesIndex.php
+++ b/app/Livewire/QuotesIndex.php
@@ -186,6 +186,7 @@ class QuotesIndex extends Component
     {
         if(is_numeric($this->idCompanie)){
             $Quotes = Quotes::withCount('QuoteLines')
+                            ->with(['Orders.processingLocation'])
                             ->where('companies_id', $this->idCompanie)
                             ->where('statu', 'like', '%'.$this->searchIdStatus.'%')
                             ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
@@ -193,6 +194,7 @@ class QuotesIndex extends Component
         }
         else{
             $Quotes = Quotes::withCount('QuoteLines')
+                            ->with(['Orders.processingLocation'])
                             ->where('label','like', '%'.$this->search.'%')
                             ->where('statu', 'like', '%'.$this->searchIdStatus.'%')
                             ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')

--- a/app/Models/Workflow/Quotes.php
+++ b/app/Models/Workflow/Quotes.php
@@ -185,6 +185,26 @@ class Quotes extends Model
         return $this->guestVisits()->count();
     }
 
+    /**
+     * Get a comma-separated list of processing locations linked to the quote.
+     *
+     * This accessor aggregates the labels of every processing location
+     * associated with the quote through its orders and returns them as a
+     * comma-separated string.
+     *
+     * @return string
+     */
+    public function getProcessingLocationsListAttribute()
+    {
+        return $this->Orders
+            ->map(function ($order) {
+                return optional($order->processingLocation)->label;
+            })
+            ->filter()
+            ->unique()
+            ->implode(', ');
+    }
+
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()->logOnly(['code', 

--- a/resources/views/livewire/quotes-index.blade.php
+++ b/resources/views/livewire/quotes-index.blade.php
@@ -397,6 +397,7 @@
                                 </th>
                                 <th>{{__('general_content.code_trans_key') }}</th>
                                 <th>{{__('general_content.lines_count_trans_key') }}</th>
+                                <th>{{ __('general_content.processing_location_trans_key') }}</th>
                                 <th>{{__('general_content.total_price_trans_key') }}</th>
                                 <th>{{__('general_content.status_trans_key') }}</th>
                                 <th>{{ __('general_content.user_trans_key') }}</th>
@@ -416,6 +417,7 @@
                                 </td>
                                 <td>{{ $Quote->customer_reference }}</td>
                                 <td>{{ $Quote->quote_lines_count }}</td>
+                                <td>{{ $Quote->processing_locations_list }}</td>
                                 <td>{{$Quote->formatted_total_price }}</td>
                                 <td>
                                     @if(1 == $Quote->statu )   <span class="badge badge-info"> {{ __('general_content.open_trans_key') }}</span>@endif
@@ -433,7 +435,7 @@
                                 </td>
                             </tr>
                             @empty
-                                <x-EmptyDataLine col="10" text="{{ __('general_content.no_data_trans_key') }}"  />
+                                <x-EmptyDataLine col="11" text="{{ __('general_content.no_data_trans_key') }}"  />
                             @endforelse
                         </tbody>
                         <tfoot>
@@ -443,6 +445,7 @@
                                 <th>{{__('general_content.customer_trans_key') }}</th>
                                 <th>{{__('general_content.code_trans_key') }}</th>
                                 <th>{{__('general_content.lines_count_trans_key') }}</th>
+                                <th>{{ __('general_content.processing_location_trans_key') }}</th>
                                 <th>{{__('general_content.total_price_trans_key') }}</th>
                                 <th>{{__('general_content.status_trans_key') }}</th>
                                 <th>{{ __('general_content.user_trans_key') }}</th>
@@ -480,6 +483,7 @@
                             <div class="card-body">
                                 <p class="card-text"><strong>{{__('general_content.total_price_trans_key') }}</strong> : {{ $Quote->formatted_total_price }}</p>
                                 <p class="card-text"><strong>{{__('general_content.lines_count_trans_key') }}</strong> : {{ $Quote->quote_lines_count  }}</p>
+                                <p class="card-text"><strong>{{ __('general_content.processing_location_trans_key') }}</strong> : {{ $Quote->processing_locations_list }}</p>
                             </div>
                             <div class="card-footer bg-secondary">
                                 <div class="row">
@@ -560,6 +564,8 @@
                                                     </div>
                                                     <div class="card-body">
                                                         <p class="card-text"><strong>{{__('general_content.total_price_trans_key') }}</strong> : {{ $Quote->formatted_total_price }}</p>
+                                                        <p class="card-text"><strong>{{__('general_content.lines_count_trans_key') }}</strong> : {{ $Quote->quote_lines_count }}</p>
+                                                        <p class="card-text"><strong>{{ __('general_content.processing_location_trans_key') }}</strong> : {{ $Quote->processing_locations_list }}</p>
                                                     </div>
                                                     <div class="card-footer bg-secondary">
                                                         <div class="row">


### PR DESCRIPTION
## Summary
- show processing locations for each quote
- load related processing locations in Livewire component

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847608d07d4833294d2702ea4d3b6e0