### PR TITLE
Add sold filter toggle to product list

### DIFF
--- a/app/Livewire/ProductsIndex.php
+++ b/app/Livewire/ProductsIndex.php
@@ -18,6 +18,9 @@ class ProductsIndex extends Component
     public $search = '';
     public $sortField = 'label'; // default sorting field
     public $sortAsc = true; // default sort direction
+
+    // Filter only sold or not sold products
+    public $showSold = true;
     
     public $userSelect = [];
 
@@ -78,6 +81,12 @@ class ProductsIndex extends Component
         $this->resetPage();
     }
 
+    public function toggleSoldFilter()
+    {
+        $this->showSold = !$this->showSold;
+        $this->resetPage();
+    }
+
     public function mount() 
     {
         $this->userSelect = User::select('id', 'name')->get();
@@ -85,7 +94,10 @@ class ProductsIndex extends Component
 
     public function render()
     {
-        $Products = Products::where('label','like', '%'.$this->search.'%')->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')->paginate(15);
+        $Products = Products::where('label', 'like', '%'.$this->search.'%')
+            ->where('sold', $this->showSold ? 1 : 2)
+            ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
+            ->paginate(15);
         $userSelect = User::select('id', 'name')->get();
         $ServicesSelect = MethodsServices::select('id', 'label')->orderBy('ordre')->get();
         $UnitsSelect = MethodsUnits::select('id', 'label', 'type')->orderBy('label')->get();

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -736,6 +736,7 @@ return [
     'index_trans_key'                          => 'الفهرس',
     'new_product_trans_key'                    => 'منتج جديد',
     'show_only_sold_trans_key'                 => 'العناصر المباعة فقط',
+    'show_only_unsold_trans_key'               => 'العناصر غير المباعة فقط',
     'price_by_qty_trans_key'                   => 'السعر حسب الكمية',
 
     'serial_numbers_trans_key'                 => 'أرقام التسلسل',

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -735,6 +735,7 @@ return [
     'other_information_trans_key'              => 'معلومات أخرى',
     'index_trans_key'                          => 'الفهرس',
     'new_product_trans_key'                    => 'منتج جديد',
+    'show_only_sold_trans_key'                 => 'العناصر المباعة فقط',
     'price_by_qty_trans_key'                   => 'السعر حسب الكمية',
 
     'serial_numbers_trans_key'                 => 'أرقام التسلسل',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -863,6 +863,7 @@ return [
     'other_information_trans_key'              => 'Other information',
     'index_trans_key'                          => 'Index',
     'new_product_trans_key'                    => 'New product',
+    'show_only_sold_trans_key'                 => 'Sold items only',
     'price_by_qty_trans_key'                   => 'Price by quantity',
     'weighted_average_price_trans_key'         => 'Weighted average price',
     'last_purchase_price_price_trans_key'      => 'Last purchase price',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -864,6 +864,7 @@ return [
     'index_trans_key'                          => 'Index',
     'new_product_trans_key'                    => 'New product',
     'show_only_sold_trans_key'                 => 'Sold items only',
+    'show_only_unsold_trans_key'               => 'Unsold items only',
     'price_by_qty_trans_key'                   => 'Price by quantity',
     'weighted_average_price_trans_key'         => 'Weighted average price',
     'last_purchase_price_price_trans_key'      => 'Last purchase price',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -736,6 +736,7 @@ return [
     'index_trans_key'                          => 'Índice',
     'new_product_trans_key'                    => 'Nuevo producto',
     'show_only_sold_trans_key'                 => 'Solo vendidos',
+    'show_only_unsold_trans_key'               => 'Solo no vendidos',
     'price_by_qty_trans_key'                   => 'Precio por cantidad',
 
     'serial_numbers_trans_key'                 => 'Números de serie',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -735,6 +735,7 @@ return [
     'other_information_trans_key'              => 'Otra información',
     'index_trans_key'                          => 'Índice',
     'new_product_trans_key'                    => 'Nuevo producto',
+    'show_only_sold_trans_key'                 => 'Solo vendidos',
     'price_by_qty_trans_key'                   => 'Precio por cantidad',
 
     'serial_numbers_trans_key'                 => 'Números de serie',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -863,6 +863,7 @@ return [
     'other_information_trans_key'              => 'Autre information',
     'index_trans_key'                          => 'Ind',
     'new_product_trans_key'                    => 'Nouveau produit',
+    'show_only_sold_trans_key'                 => 'Uniquement les vendus',
     'price_by_qty_trans_key'                   => 'Prix par quantité',
     'weighted_average_price_trans_key'         => 'Prix ​​moyen pondéré',
     'last_purchase_price_price_trans_key'      => 'Dernier prix d\'achat',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -864,6 +864,7 @@ return [
     'index_trans_key'                          => 'Ind',
     'new_product_trans_key'                    => 'Nouveau produit',
     'show_only_sold_trans_key'                 => 'Uniquement les vendus',
+    'show_only_unsold_trans_key'               => 'Uniquement les non vendus',
     'price_by_qty_trans_key'                   => 'Prix par quantité',
     'weighted_average_price_trans_key'         => 'Prix ​​moyen pondéré',
     'last_purchase_price_price_trans_key'      => 'Dernier prix d\'achat',

--- a/resources/views/livewire/products-index.blade.php
+++ b/resources/views/livewire/products-index.blade.php
@@ -324,8 +324,14 @@
     <div class="card">
         <div class="card-body">
             <div class="row">
-                <div class="col-md-10">
+                <div class="col-md-8">
                     @include('include.search-card')
+                </div>
+                <div class="col-md-2">
+                    <div class="form-check mt-2">
+                        <input class="form-check-input" type="checkbox" id="soldFilter" wire:click="toggleSoldFilter" @if($showSold) checked @endif>
+                        <label class="form-check-label" for="soldFilter">{{ __('general_content.show_only_sold_trans_key') }}</label>
+                    </div>
                 </div>
                 <div class="col-md-2">
                     <button type="button" class="btn btn-success float-sm-right" data-toggle="modal" data-target="#ModalProduct">

--- a/resources/views/livewire/products-index.blade.php
+++ b/resources/views/livewire/products-index.blade.php
@@ -328,9 +328,17 @@
                     @include('include.search-card')
                 </div>
                 <div class="col-md-2">
-                    <div class="form-check mt-2">
-                        <input class="form-check-input" type="checkbox" id="soldFilter" wire:click="toggleSoldFilter" @if($showSold) checked @endif>
-                        <label class="form-check-label" for="soldFilter">{{ __('general_content.show_only_sold_trans_key') }}</label>
+                    <div class="form-inline mt-2">
+                        <x-adminlte-input-switch id="soldFilterSwitch" name="soldFilterSwitch"
+                            data-on-text="{{ __('general_content.yes_trans_key') }}"
+                            data-off-text="{{ __('general_content.no_trans_key') }}"
+                            data-on-color="teal"
+                            wire:click="toggleSoldFilter"
+                            class="mr-1"
+                            is-checked="{{ $showSold }}" />
+                        <label class="ml-2" for="soldFilterSwitch">
+                            {{ $showSold ? __('general_content.show_only_sold_trans_key') : __('general_content.show_only_unsold_trans_key') }}
+                        </label>
                     </div>
                 </div>
                 <div class="col-md-2">


### PR DESCRIPTION
## Summary
- add `showSold` filter to `ProductsIndex` Livewire component
- show only sold or unsold products depending on new checkbox
- add translation key for toggle label in all languages
- update products list view with checkbox toggle

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848594e9e9c8332a5430d72a9a8be6c