### PR TITLE
Add toggle filter for sold products

### DIFF
--- a/app/Livewire/ProductsIndex.php
+++ b/app/Livewire/ProductsIndex.php
@@ -18,8 +18,14 @@ class ProductsIndex extends Component
     public $search = '';
     public $sortField = 'label'; // default sorting field
     public $sortAsc = true; // default sort direction
-    
+
     public $userSelect = [];
+
+    /**
+     * When true only sold products are shown. When false only unsold products are listed.
+     * @var bool
+     */
+    public $filterSold = true;
 
     public $code;
     public $label;  
@@ -78,14 +84,24 @@ class ProductsIndex extends Component
         $this->resetPage();
     }
 
-    public function mount() 
+    public function mount()
     {
         $this->userSelect = User::select('id', 'name')->get();
+        $this->filterSold = true;
     }
 
     public function render()
     {
-        $Products = Products::where('label','like', '%'.$this->search.'%')->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')->paginate(15);
+        $Products = Products::where('label', 'like', '%'.$this->search.'%')
+            ->when($this->filterSold !== null, function ($query) {
+                if ($this->filterSold) {
+                    $query->where('sold', 1);
+                } else {
+                    $query->where('sold', '!=', 1);
+                }
+            })
+            ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
+            ->paginate(15);
         $userSelect = User::select('id', 'name')->get();
         $ServicesSelect = MethodsServices::select('id', 'label')->orderBy('ordre')->get();
         $UnitsSelect = MethodsUnits::select('id', 'label', 'type')->orderBy('label')->get();

--- a/resources/lang/ar/general_content.php
+++ b/resources/lang/ar/general_content.php
@@ -725,6 +725,7 @@ return [
     'selling_price_trans_key'                  => 'سعر البيع',
     'purchased_trans_key'                      => 'مشترى',
     'sold_trans_key'                           => 'مباع',
+    'unsold_trans_key'                         => 'غير مباع',
     'tracability_trans_key'                    => 'تتبع',
     'proprieties_trans_key'                    => 'خصائص',
     'quantite_eco_min_trans_key'               => 'الحد الأدنى لكمية مستدامة',

--- a/resources/lang/en/general_content.php
+++ b/resources/lang/en/general_content.php
@@ -853,6 +853,7 @@ return [
     'selling_price_trans_key'                  => 'Selling price',
     'purchased_trans_key'                      => 'Purchased',
     'sold_trans_key'                           => 'Sold',
+    'unsold_trans_key'                         => 'Not sold',
     'tracability_trans_key'                    => 'Tracability',
     'proprieties_trans_key'                    => 'Proprieties',
     'quantite_eco_min_trans_key'               => 'Qty eco min',

--- a/resources/lang/es/general_content.php
+++ b/resources/lang/es/general_content.php
@@ -725,6 +725,7 @@ return [
     'selling_price_trans_key'                  => 'Precio de venta',
     'purchased_trans_key'                      => 'Comprado',
     'sold_trans_key'                           => 'Vendido',
+    'unsold_trans_key'                         => 'No vendido',
     'tracability_trans_key'                    => 'Trazabilidad',
     'proprieties_trans_key'                    => 'Propiedades',
     'quantite_eco_min_trans_key'               => 'Cantidad eco mínima',

--- a/resources/lang/fr/general_content.php
+++ b/resources/lang/fr/general_content.php
@@ -853,6 +853,7 @@ return [
     'selling_price_trans_key'                  => 'Prix de vente ',
     'purchased_trans_key'                      => 'Acheté',
     'sold_trans_key'                           => 'Vendu',
+    'unsold_trans_key'                         => 'Non vendu',
     'tracability_trans_key'                    => 'Tracabilité',
     'proprieties_trans_key'                    => 'Propriétés',
     'quantite_eco_min_trans_key'               => 'Quantité eco min',

--- a/resources/views/livewire/products-index.blade.php
+++ b/resources/views/livewire/products-index.blade.php
@@ -324,8 +324,15 @@
     <div class="card">
         <div class="card-body">
             <div class="row">
-                <div class="col-md-10">
+                <div class="col-md-8">
                     @include('include.search-card')
+                </div>
+                <div class="col-md-2">
+                    <x-adminlte-input-switch wire:model.live="filterSold"
+                                             name="filterSold"
+                                             data-on-text="{{ __('general_content.sold_trans_key') }}"
+                                             data-off-text="{{ __('general_content.unsold_trans_key') }}"
+                                             data-on-color="teal"/>
                 </div>
                 <div class="col-md-2">
                     <button type="button" class="btn btn-success float-sm-right" data-toggle="modal" data-target="#ModalProduct">


### PR DESCRIPTION
## Summary
- add Livewire property to filter sold products
- add toggle UI component to switch between sold and unsold items
- localize 'unsold' text in four languages

## Testing
- `composer test` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486076778c8332b67147dbc76e24f0