### PR TITLE
Customize iframe loading screen

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -132,4 +132,32 @@
 }
 .place-3 {
     background-color: bronze;
+}.tab-loading > div {
+    flex-direction: column;
+}
+.tab-loading .iframe-logo {
+    width: 100px;
+    margin-bottom: 10px;
+}
+.tab-loading .iframe-progress {
+    width: 80%;
+    height: 8px;
+    background-color: #e0e0e0;
+    overflow: hidden;
+    position: relative;
+    border-radius: 4px;
+}
+.tab-loading .iframe-progress::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0;
+    background-color: #007bff;
+    animation: iframe-progress 2s linear infinite;
+}
+@keyframes iframe-progress {
+    from { width: 0; }
+    to { width: 100%; }
 }

--- a/resources/views/iframe-mode.blade.php
+++ b/resources/views/iframe-mode.blade.php
@@ -10,7 +10,19 @@
 @stop
 
 @section('css')
+    <link rel="stylesheet" href="{{ asset('css/custom.css') }}">
 @stop
 
 @section('js')
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            var loadingDiv = document.querySelector('.tab-loading > div');
+            if (loadingDiv) {
+                loadingDiv.innerHTML = `
+                    <img src="{{ asset('images/factory/1708549820_simple-logo.jpg') }}" class="iframe-logo" alt="Logo">
+                    <div class="iframe-progress"></div>
+                `;
+            }
+        });
+    </script>
 @stop


### PR DESCRIPTION
## Summary
- add custom styles for the iframe loading overlay
- update iframe view to insert a logo and progress bar

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68486e91bee88332b0e3e36b01341501