### PR TITLE
Enable draggable dashboard layout

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -38,7 +38,7 @@
   </div>
   @endif
 
-  <div class="row ">
+  <div class="row" id="dashboard-row">
     <div class="col-lg-2">
       <x-adminlte-small-box title="{{$data['customers_count']}}"
                             text="{{ __('general_content.new_client_trans_key') }}" 
@@ -712,6 +712,41 @@
       setInterval(startUpdateProcedure, 10000);
   })
 
+</script>
+
+<!-- Drag and drop dashboard tiles -->
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+      const container = document.getElementById('dashboard-row');
+      if (!container) return;
+
+      // Ensure each child tile has an id
+      Array.from(container.children).forEach((el, idx) => {
+          if (!el.id) {
+              el.id = 'tile-' + idx;
+          }
+      });
+
+      // Apply saved order
+      const saved = localStorage.getItem('dashboard-order');
+      if (saved) {
+          saved.split(',').forEach(id => {
+              const el = document.getElementById(id);
+              if (el) container.appendChild(el);
+          });
+      }
+
+      // Init Sortable
+      Sortable.create(container, {
+          animation: 150,
+          handle: '.card, .small-box',
+          onEnd: () => {
+              const order = Array.from(container.children).map(el => el.id);
+              localStorage.setItem('dashboard-order', order.join(','));
+          }
+      });
+  });
 </script>
 
 @stop


### PR DESCRIPTION
## Summary
- allow draggable positioning for all dashboard tiles and cards using SortableJS
- persist tile order in `localStorage` and restore on page load

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684897c631fc83329270bf65919d5b9f