### PR TITLE
Fix quote line overflow

### DIFF
--- a/resources/views/livewire/quote-lines.blade.php
+++ b/resources/views/livewire/quote-lines.blade.php
@@ -55,11 +55,11 @@
                                     <a href="#" wire:click="downQuoteLine({{ $QuoteLine->id }})" class="btn btn-primary"><i class="fas fa-sort-down"></i></a>
                                 </div>
                             </td>
-                            <td>{{ $QuoteLine->code }}</td>
+                            <td class="text-break">{{ $QuoteLine->code }}</td>
                             <td>
                                 @if($QuoteLine->product_id ) <x-ButtonTextView route="{{ route('products.show', ['id' => $QuoteLine->product_id])}}" />@endif
                             </td>
-                            <td>{{ $QuoteLine->label }}</td>
+                            <td class="text-break">{{ $QuoteLine->label }}</td>
                             <td>{{ $QuoteLine->qty }}</td>
                             <td>{{ $QuoteLine->Unit['label'] }}</td>
                             <td @if($QuoteLine->use_calculated_price) class="bg-warning color-palette" @endif>

--- a/resources/views/livewire/quotes-lines-index.blade.php
+++ b/resources/views/livewire/quotes-lines-index.blade.php
@@ -39,11 +39,11 @@
                                 <x-QuoteButton id="{{ $QuoteLine->quotes_id }}" code="{{ $QuoteLine->quote['code'] }}"  />
                             </td>
                             <td>{{ $QuoteLine->ordre }}</td>
-                            <td>{{ $QuoteLine->code }}</td>
+                            <td class="text-break">{{ $QuoteLine->code }}</td>
                             <td>
                                 @if($QuoteLine->product_id ) <x-ButtonTextView route="{{ route('products.show', ['id' => $QuoteLine->product_id])}}" />@endif
                             </td>
-                            <td>{{ $QuoteLine->label }}</td>
+                            <td class="text-break">{{ $QuoteLine->label }}</td>
                             <td>{{ $QuoteLine->qty }}</td>
                             <td>{{ $QuoteLine->Unit['label'] }}</td>
                             <td @if($QuoteLine->use_calculated_price) class="bg-warning color-palette" @endif>


### PR DESCRIPTION
## Summary
- prevent text overlap in quote lines tables

## Testing
- `npm test` *(fails: Missing script)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68489c654d6c833294937250d0260d4f