### PR TITLE
Auto populate code and label on product select

### DIFF
--- a/resources/views/livewire/form/line-create.blade.php
+++ b/resources/views/livewire/form/line-create.blade.php
@@ -19,7 +19,7 @@
                 </x-slot>
                 <option value="">{{ __('general_content.select_product_trans_key') }}</option>
                 @foreach ($ProductsSelect as $item)
-                <option value="{{ $item->id }}" data-txt="{{ $item->code }}">{{ $item->code }} - {{ $item->label }}</option>
+                <option value="{{ $item->id }}" data-code="{{ $item->code }}" data-label="{{ $item->label }}">{{ $item->code }} - {{ $item->label }}</option>
                 @endforeach
             </x-adminlte-select2>
             @error('product_id') <span class="text-danger">{{ $message }}<br/></span>@enderror
@@ -85,3 +85,17 @@
         </div>
     </div>
 </form>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const productSelect = document.getElementById('product_id');
+    if (productSelect) {
+        productSelect.addEventListener('change', function () {
+            const option = this.options[this.selectedIndex];
+            if (option) {
+                document.getElementById('code').value = option.dataset.code || '';
+                document.getElementById('label').value = option.dataset.label || '';
+            }
+        });
+    }
+});
+</script>


### PR DESCRIPTION
## Summary
- add `data-code` and `data-label` attributes to each product option
- include a JS snippet that fills External ID and Description when a product is selected

## Testing
- `php -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6848afb133f08332b06eef3e9a127647