### PR TITLE
Embed accounting report iframe

### DIFF
--- a/resources/views/reports/accounting.blade.php
+++ b/resources/views/reports/accounting.blade.php
@@ -7,5 +7,5 @@
 @stop
 
 @section('content')
-    <iframe src="http://msi/Reports/browse/Accounting%20Reports" style="width: 100%; height: 80vh; border: none;"></iframe>
+    <iframe src="http://ReportServer:Report123@msi/Reports/browse/Accounting%20Reports" style="width: 100%; height: 80vh; border: none;"></iframe>
 @stop

--- a/resources/views/reports/accounting.blade.php
+++ b/resources/views/reports/accounting.blade.php
@@ -7,24 +7,5 @@
 @stop
 
 @section('content')
-<div class="row">
-    <div class="col-md-4">
-        <x-adminlte-card title="{{ __('general_content.total_revenue_trans_key') }}" theme="success" icon="fas fa-coins" >
-            {{ \Illuminate\Support\Number::currency($revenue, app('Factory')->curency, config('app.locale')) }}
-        </x-adminlte-card>
-    </div>
-    <div class="col-md-4">
-        <x-adminlte-card title="{{ __('general_content.total_expense_trans_key') }}" theme="danger" icon="fas fa-file-invoice-dollar" >
-            {{ \Illuminate\Support\Number::currency($expenses, app('Factory')->curency, config('app.locale')) }}
-        </x-adminlte-card>
-    </div>
-    <div class="col-md-4">
-        <x-adminlte-card title="{{ __('general_content.total_profit_trans_key') }}" theme="primary" icon="fas fa-chart-line" >
-            {{ \Illuminate\Support\Number::currency($profit, app('Factory')->curency, config('app.locale')) }}
-        </x-adminlte-card>
-    </div>
-</div>
-<div class="mt-4">
-    @livewire('fec-export-lines')
-</div>
+    <iframe src="http://msi/Reports/browse/Accounting%20Reports" style="width: 100%; height: 80vh; border: none;"></iframe>
 @stop


### PR DESCRIPTION
## Summary
- use an iframe in Accounting reports view to display http://msi/Reports/browse/Accounting%20Reports within the admin layout

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853200bcd2083329149824a90293f6a