### PR TITLE
Fix missing status check

### DIFF
--- a/app/Livewire/TaskStatu.php
+++ b/app/Livewire/TaskStatu.php
@@ -264,8 +264,8 @@ class TaskStatu extends Component
         $StatusUpdate = Status::select('id')->where('title', 'In progress')->first();
 
         /* // update task statu on Kanban*/
-        if($StatusUpdate->id){
-            $Task = Task::where('id',$taskId)->update(['status_id'=>$StatusUpdate->id]);
+        if ($StatusUpdate) {
+            Task::where('id', $taskId)->update(['status_id' => $StatusUpdate->id]);
             event(new TaskChangeStatu($taskId));
         }
 
@@ -294,8 +294,8 @@ class TaskStatu extends Component
         $StatusUpdate = Status::select('id')->where('title', 'Finished')->first();
 
         /* // update task statu on Kanban*/
-        if($StatusUpdate->id){
-            $Task = Task::where('id',$taskId)->update(['status_id'=>$StatusUpdate->id]);
+        if ($StatusUpdate) {
+            Task::where('id', $taskId)->update(['status_id' => $StatusUpdate->id]);
             event(new TaskChangeStatu($taskId));
         }
 


### PR DESCRIPTION
## Summary
- handle missing status when updating a task state

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685dbebafc088332b6f3dfa737b3ab08